### PR TITLE
[vnet] fix leftovers: remove 'INTERFACE' entry from redis and add VLAN_MEMBER back in Cleanup block

### DIFF
--- a/tests/vxlan/vnet_utils.py
+++ b/tests/vxlan/vnet_utils.py
@@ -146,6 +146,10 @@ def cleanup_dut_vnets(duthost, mg_facts, vnet_config):
     for vnet in vnet_config['vnet_id_list']:
         duthost.shell("redis-cli -n 4 del \"VNET|{}\"".format(vnet))
 
+    for intf in vnet_config['intf_list']:
+        duthost.shell("redis-cli -n 4 del \"INTERFACE|{}|{}\"".format(intf['ifname'], intf['ip']))
+        duthost.shell("redis-cli -n 4 del \"INTERFACE|{}\"".format(intf['ifname']))
+
 def cleanup_vxlan_tunnels(duthost, vnet_test_params):
     """
     Removes all VxLAN tunnels from DUT


### PR DESCRIPTION
…N_MEMBER back in Cleanup block

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
fix leftovers that remained after test execution
#### How did you do it?
I removed remained vnet related config and added Ethernet4 interface back to VLAN1000
#### How did you verify/test it?
run `py.test vxlan/test_vnet_vxlan.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern arc-switch1041-t0 --module-path ../ansible/library/ --testbed arc-switch1041-t0 --testbed_file ../ansible/testbed.csv --skip_sanity --disable_loganalyzer -v --log-cli-level info` <--- this test may add leftovers (before this fix)
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
