### PR TITLE
Set storm_start=True if test_action is 'detect'

### DIFF
--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -502,7 +502,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
 
                     self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd, queue)
                     self.run_test(port, queue, detect=(bitmask & 1),
-                                  storm_start=not t_idx or storm_deferred or storm_restored,
+                                  storm_start=('detect' in test_action) or storm_deferred or storm_restored,
                                   first_detect_after_wb=(t_idx == 2 and not p_idx and not q_idx and not storm_deferred),
                                   storm_defer=(bitmask & 4))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Handle case when **test_pfcwd_warm_reboot.py** test use few interfaces instead of only one.
It is possible because interfaces for testing generated using **select_test_ports()** function from  **tests/pfcwd/files/pfcwd_helper.py**  

#### How did you do it?
I have modified checking of condition that determined certain actions in the detect logic.
Instead of checking index in test sequence we are looking for exact value in it.

#### How did you verify/test it?
Problem reproduced on **t0** topology
run` py.test pfcwd/test_pfcwd_warm_reboot.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern arc-switch1041-t0 --module-path                ../ansible/library/ --testbed arc-switch1041-t0 --testbed_file ../ansible/testbed.csv                --allow_recover                --junit-xml xxx.xml --assert plain  -vvvv --log-cli-level info -c pytest.ini`
Test should finish without error "AssertionError: Received packet that we expected not to receive on device 0, port 9."

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
